### PR TITLE
Create mirror_permissions

### DIFF
--- a/mirror_permissions
+++ b/mirror_permissions
@@ -23,7 +23,7 @@ find_children() {
                                         for role in ${BINDINGS}
                                         do
                                         gcloud projects add-iam-policy-binding $project_id --quiet --member="group:${NEW_GROUP}" --role="${role}"
-                                        echo "Set ${role} on ${project_id} for ${NEW_GROUP}"csg
+                                        echo "Set ${role} on ${project_id} for ${NEW_GROUP}"
                                         done
                                 done <<< "$PROJECT_IDS"
                         fi

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -14,7 +14,7 @@ find_children() {
                         for role in ${BINDINGS}
                         do
                         gcloud resource-manager folders add-iam-policy-binding $sub_folder --member="group:${NEW_CSG}" --role="${role}"
-                        echo "set ${role} on ${sub_folder} for jeremy"
+                        echo "Set ${role} on ${sub_folder} for ${NEW_GROUP}"
                         done
                         PROJECT_IDS=`gcloud projects list --filter=" parent.id: '$sub_folder' " --format json | jq -r '.[] | .projectId'`
                         if [ "$PROJECT_IDS" ]; then
@@ -23,7 +23,7 @@ find_children() {
                                         for role in ${BINDINGS}
                                         do
                                         gcloud projects add-iam-policy-binding $project_id --member="group:${NEW_CSG}" --role="${role}"
-                                        echo "set ${role} on ${project_id} for jeremy"
+                                        echo "Set ${role} on ${project_id} for ${NEW_GROUP}"
                                         done
                                 done <<< "$PROJECT_IDS"
                         fi
@@ -42,7 +42,7 @@ BINDINGS=`gcloud organizations get-iam-policy $ORG_ID --flatten="bindings[].memb
 for role in ${BINDINGS}
 do
 gcloud organizations add-iam-policy-binding $ORG_ID --member="group:${NEW_CSG}" --role="${role}"
-echo "doing org"
+echo "Set ${role} on ${ORG_ID} for ${NEW_GROUP}"
 done
 SUB_FOLDERS=`gcloud resource-manager folders list --organization $ORG_ID --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`
 find_children $SUB_FOLDERS

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -1,0 +1,48 @@
+# To find where a user is getting his or her access, run the following command:
+# DOCUMENTS=`find ~/[ORG_NAME]/ -name *json`;while IFS= read -r document;do echo "Policy: $document";cat $document | jq '.bindings[].members[]';done <<< "$DOCUMENTS"
+
+#!/bin/bash
+
+# format of group:mygroup@example.com
+GROUP_TO_MIRROR=""
+NEW_GROUP=""
+
+find_children() {
+                while IFS= read -r sub_folder;do
+                        folder_name=`gcloud resource-manager folders describe $sub_folder --format json | jq -r '.displayName' | sed 's/\ /_/g'`
+                        BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+                        for role in ${BINDINGS}
+                        do
+                        gcloud resource-manager folders add-iam-policy-binding $sub_folder --member="group:${NEW_CSG}" --role="${role}"
+                        echo "set ${role} on ${sub_folder} for jeremy"
+                        done
+                        PROJECT_IDS=`gcloud projects list --filter=" parent.id: '$sub_folder' " --format json | jq -r '.[] | .projectId'`
+                        if [ "$PROJECT_IDS" ]; then
+                                while IFS= read -r project_id;do
+                                        BINDINGS=`gcloud projects get-iam-policy $project_id --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+                                        for role in ${BINDINGS}
+                                        do
+                                        gcloud projects add-iam-policy-binding $project_id --member="group:${NEW_CSG}" --role="${role}"
+                                        echo "set ${role} on ${project_id} for jeremy"
+                                        done
+                                done <<< "$PROJECT_IDS"
+                        fi
+                        SUB_FOLDERS=`gcloud resource-manager folders list --folder $sub_folder --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`
+                        if [ "$SUB_FOLDERS" ];then
+                                find_children $SUB_FOLDERS
+                        fi
+                done <<< "$SUB_FOLDERS"
+}
+
+
+
+ORG_ID=`gcloud organizations list --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`
+ORG_NAME=`gcloud organizations describe $ORG_ID --format json | jq -r '.displayName'`
+BINDINGS=`gcloud organizations get-iam-policy $ORG_ID --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+for role in ${BINDINGS}
+do
+gcloud organizations add-iam-policy-binding $ORG_ID --member="group:${NEW_CSG}" --role="${role}"
+echo "doing org"
+done
+SUB_FOLDERS=`gcloud resource-manager folders list --organization $ORG_ID --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`
+find_children $SUB_FOLDERS

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -1,5 +1,5 @@
-# To find where a user is getting his or her access, run the following command:
-# DOCUMENTS=`find ~/[ORG_NAME]/ -name *json`;while IFS= read -r document;do echo "Policy: $document";cat $document | jq '.bindings[].members[]';done <<< "$DOCUMENTS"
+# To mirror roles between two groups in GCP. First, set GROUP_TO_MIRROR to be the group whose permissions you want to mirror. Secondly, set NEW_GROUP to the group
+# that will receive new roles based on the roles the current group has.
 
 #!/bin/bash
 

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -1,9 +1,10 @@
+#!/bin/bash
+
 # To mirror roles between two groups in GCP. First, set GROUP_TO_MIRROR to be the group whose permissions you want to mirror. Secondly, set NEW_GROUP to the group
 # that will receive new roles based on the roles the current group has.
 
-#!/bin/bash
 
-# format of group:mygroup@example.com
+# format of mygroup@example.com
 GROUP_TO_MIRROR=""
 NEW_GROUP=""
 

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -10,20 +10,20 @@ NEW_GROUP=""
 
 find_children() {
                 while IFS= read -r sub_folder;do
-                        BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+                        BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${GROUP_TO_MIRRO}" | grep role |sed -e 's/role: //'`
                         for role in ${BINDINGS}
                         do
-                        gcloud resource-manager folders add-iam-policy-binding $sub_folder --quiet --member="group:${NEW_CSG}" --role="${role}"
+                        gcloud resource-manager folders add-iam-policy-binding $sub_folder --quiet --member="group:${NEW_GROUP}" --role="${role}"
                         echo "Set ${role} on ${sub_folder} for ${NEW_GROUP}"
                         done
                         PROJECT_IDS=`gcloud projects list --filter=" parent.id: '$sub_folder' " --format json | jq -r '.[] | .projectId'`
                         if [ "$PROJECT_IDS" ]; then
                                 while IFS= read -r project_id;do
-                                        BINDINGS=`gcloud projects get-iam-policy $project_id --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+                                        BINDINGS=`gcloud projects get-iam-policy $project_id --flatten="bindings[].members" --filter="bindings.members:${GROUP_TO_MIRROR}" | grep role |sed -e 's/role: //'`
                                         for role in ${BINDINGS}
                                         do
-                                        gcloud projects add-iam-policy-binding $project_id --quiet --member="group:${NEW_CSG}" --role="${role}"
-                                        echo "Set ${role} on ${project_id} for ${NEW_GROUP}"
+                                        gcloud projects add-iam-policy-binding $project_id --quiet --member="group:${NEW_GROUP}" --role="${role}"
+                                        echo "Set ${role} on ${project_id} for ${NEW_GROUP}"csg
                                         done
                                 done <<< "$PROJECT_IDS"
                         fi
@@ -38,10 +38,10 @@ find_children() {
 
 ORG_ID=`gcloud organizations list --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`
 ORG_NAME=`gcloud organizations describe $ORG_ID --format json | jq -r '.displayName'`
-BINDINGS=`gcloud organizations get-iam-policy $ORG_ID --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
+BINDINGS=`gcloud organizations get-iam-policy $ORG_ID --flatten="bindings[].members" --filter="bindings.members:${GROUP_TO_MIRROR}" | grep role |sed -e 's/role: //'`
 for role in ${BINDINGS}
 do
-gcloud organizations add-iam-policy-binding $ORG_ID --quiet --member="group:${NEW_CSG}" --role="${role}"
+gcloud organizations add-iam-policy-binding $ORG_ID --quiet --member="group:${NEW_GROUP}" --role="${role}"
 echo "Set ${role} on ${ORG_ID} for ${NEW_GROUP}"
 done
 SUB_FOLDERS=`gcloud resource-manager folders list --organization $ORG_ID --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -9,7 +9,6 @@ NEW_GROUP=""
 
 find_children() {
                 while IFS= read -r sub_folder;do
-                        folder_name=`gcloud resource-manager folders describe $sub_folder --format json | jq -r '.displayName' | sed 's/\ /_/g'`
                         BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
                         for role in ${BINDINGS}
                         do

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -12,7 +12,7 @@ find_children() {
                         BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
                         for role in ${BINDINGS}
                         do
-                        gcloud resource-manager folders add-iam-policy-binding $sub_folder --member="group:${NEW_CSG}" --role="${role}"
+                        gcloud resource-manager folders add-iam-policy-binding $sub_folder --quiet --member="group:${NEW_CSG}" --role="${role}"
                         echo "Set ${role} on ${sub_folder} for ${NEW_GROUP}"
                         done
                         PROJECT_IDS=`gcloud projects list --filter=" parent.id: '$sub_folder' " --format json | jq -r '.[] | .projectId'`
@@ -21,7 +21,7 @@ find_children() {
                                         BINDINGS=`gcloud projects get-iam-policy $project_id --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
                                         for role in ${BINDINGS}
                                         do
-                                        gcloud projects add-iam-policy-binding $project_id --member="group:${NEW_CSG}" --role="${role}"
+                                        gcloud projects add-iam-policy-binding $project_id --quiet --member="group:${NEW_CSG}" --role="${role}"
                                         echo "Set ${role} on ${project_id} for ${NEW_GROUP}"
                                         done
                                 done <<< "$PROJECT_IDS"
@@ -40,7 +40,7 @@ ORG_NAME=`gcloud organizations describe $ORG_ID --format json | jq -r '.displayN
 BINDINGS=`gcloud organizations get-iam-policy $ORG_ID --flatten="bindings[].members" --filter="bindings.members:${OLD_CSG}" | grep role |sed -e 's/role: //'`
 for role in ${BINDINGS}
 do
-gcloud organizations add-iam-policy-binding $ORG_ID --member="group:${NEW_CSG}" --role="${role}"
+gcloud organizations add-iam-policy-binding $ORG_ID --quiet --member="group:${NEW_CSG}" --role="${role}"
 echo "Set ${role} on ${ORG_ID} for ${NEW_GROUP}"
 done
 SUB_FOLDERS=`gcloud resource-manager folders list --organization $ORG_ID --format json | jq -r '.[] | .name' | sed -e 's/.*\///'`

--- a/mirror_permissions
+++ b/mirror_permissions
@@ -10,7 +10,7 @@ NEW_GROUP=""
 
 find_children() {
                 while IFS= read -r sub_folder;do
-                        BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${GROUP_TO_MIRRO}" | grep role |sed -e 's/role: //'`
+                        BINDINGS=`gcloud resource-manager folders get-iam-policy $sub_folder --flatten="bindings[].members" --filter="bindings.members:${GROUP_TO_MIRROR}" | grep role |sed -e 's/role: //'`
                         for role in ${BINDINGS}
                         do
                         gcloud resource-manager folders add-iam-policy-binding $sub_folder --quiet --member="group:${NEW_GROUP}" --role="${role}"


### PR DESCRIPTION
This script will traverse an org looking for bindings where a specific group has roles. When found, a new group will be given the same roles in that location.